### PR TITLE
maybe fix for https://mods.factorio.com/mod/enemy-alert/discussion/67c81618eb26cab9464afe0d

### DIFF
--- a/control.lua
+++ b/control.lua
@@ -50,40 +50,40 @@ script.on_event(defines.events.on_unit_group_finished_gathering, function(event)
     -- Check if the group is valid and belongs to the enemy force
     if group and group.valid and group.force.name == "enemy" then
         -- Get the group's command(s)
-		if group.command then
-			for _, command in pairs(group.command.type == defines.command.compound and group.command.commands or {group.command}) do
-				if not command.destination then
-					break
-				end
-				
-				local surface = group.surface
-				local pin     = surface.create_entity({
-					name = "pin",
-					position = command.destination,
-					force = "neutral"
-				})
+        if group.command then
+            for _, command in pairs(group.command.type == defines.command.compound and group.command.commands or {group.command}) do
+                if not command.destination then
+                    break
+                end
+                
+                local surface = group.surface
+                local pin     = surface.create_entity({
+                    name = "pin",
+                    position = command.destination,
+                    force = "neutral"
+                })
 
-				-- Alert players
-				if pin and pin.valid then
-					-- Notify players on the same surface
-					for _, player in pairs(game.connected_players) do
-						if player.valid and player.surface == surface and player.is_alert_enabled(defines.alert_type.custom) then
-							-- Create the custom alert with the dummy entity indicating the position of the enemy group
-							if command.type == defines.command.build_base and player.mod_settings["enemy-alert-expand"].value then
-								player.add_custom_alert(pin, icons["warning"], { "enemy-alert.unit-group-expand", #group.members }, true)
-							elseif command.type == defines.command.attack_area and player.mod_settings["enemy-alert-attack"].value then
-								player.add_custom_alert(pin, icons["danger"], { "enemy-alert.unit-group-attack", #group.members }, true)
+                -- Alert players
+                if pin and pin.valid then
+                    -- Notify players on the same surface
+                    for _, player in pairs(game.connected_players) do
+                        if player.valid and player.surface == surface and player.is_alert_enabled(defines.alert_type.custom) then
+                            -- Create the custom alert with the dummy entity indicating the position of the enemy group
+                            if command.type == defines.command.build_base and player.mod_settings["enemy-alert-expand"].value then
+                                player.add_custom_alert(pin, icons["warning"], { "enemy-alert.unit-group-expand", #group.members }, true)
+                            elseif command.type == defines.command.attack_area and player.mod_settings["enemy-alert-attack"].value then
+                                player.add_custom_alert(pin, icons["danger"], { "enemy-alert.unit-group-attack", #group.members }, true)
 
-								if player.mod_settings["enemy-alert-notification-sound"].value then
-									player.play_sound(sounds["alert"])
-								end
-							end
-						end
-					end
+                                if player.mod_settings["enemy-alert-notification-sound"].value then
+                                    player.play_sound(sounds["alert"])
+                                end
+                            end
+                        end
+                    end
 
-					-- Destroy pin entity
-					pin.destroy()
-				end
+                    -- Destroy pin entity
+                    pin.destroy()
+                end
             end
         end
     end

--- a/control.lua
+++ b/control.lua
@@ -49,37 +49,41 @@ script.on_event(defines.events.on_unit_group_finished_gathering, function(event)
     local group = event.group
     -- Check if the group is valid and belongs to the enemy force
     if group and group.valid and group.force.name == "enemy" then
-        -- Get the group's command
-        local command = group.command
+        -- Get the group's command(s)
+		if group.command then
+			for _, command in pairs(group.command.type == defines.command.compound and group.command.commands or {group.command}) do
+				if not command.destination then
+					break
+				end
+				
+				local surface = group.surface
+				local pin     = surface.create_entity({
+					name = "pin",
+					position = command.destination,
+					force = "neutral"
+				})
 
-        if command then
-            local surface = group.surface
-            local pin     = surface.create_entity({
-                name = "pin",
-                position = command.destination,
-                force = "neutral"
-            })
+				-- Alert players
+				if pin and pin.valid then
+					-- Notify players on the same surface
+					for _, player in pairs(game.connected_players) do
+						if player.valid and player.surface == surface and player.is_alert_enabled(defines.alert_type.custom) then
+							-- Create the custom alert with the dummy entity indicating the position of the enemy group
+							if command.type == defines.command.build_base and player.mod_settings["enemy-alert-expand"].value then
+								player.add_custom_alert(pin, icons["warning"], { "enemy-alert.unit-group-expand", #group.members }, true)
+							elseif command.type == defines.command.attack_area and player.mod_settings["enemy-alert-attack"].value then
+								player.add_custom_alert(pin, icons["danger"], { "enemy-alert.unit-group-attack", #group.members }, true)
 
-            -- Alert players
-            if pin and pin.valid then
-                -- Notify players on the same surface
-                for _, player in pairs(game.connected_players) do
-                    if player.valid and player.surface == surface and player.is_alert_enabled(defines.alert_type.custom) then
-                        -- Create the custom alert with the dummy entity indicating the position of the enemy group
-                        if command.type == defines.command.build_base and player.mod_settings["enemy-alert-expand"].value then
-                            player.add_custom_alert(pin, icons["warning"], { "enemy-alert.unit-group-expand", #group.members }, true)
-                        elseif command.type == defines.command.attack_area and player.mod_settings["enemy-alert-attack"].value then
-                            player.add_custom_alert(pin, icons["danger"], { "enemy-alert.unit-group-attack", #group.members }, true)
+								if player.mod_settings["enemy-alert-notification-sound"].value then
+									player.play_sound(sounds["alert"])
+								end
+							end
+						end
+					end
 
-                            if player.mod_settings["enemy-alert-notification-sound"].value then
-                                player.play_sound(sounds["alert"])
-                            end
-                        end
-                    end
-                end
-
-                -- Destroy pin entity
-                pin.destroy()
+					-- Destroy pin entity
+					pin.destroy()
+				end
             end
         end
     end


### PR DESCRIPTION
Hi there. Based on my digging in https://mods.factorio.com/mod/enemy-alert/discussion/67c81618eb26cab9464afe0d, I tried to come up with a solution; when I iterate over the individual commands when it's a compound command, it seems to work again (I "tested" it (i.e., played a few hours) with https://mods.factorio.com/mod/enemyracemanager, not https://mods.factorio.com/mod/RampantFixed, as first reported, though I guess it should work there, too...).

I'm not a Factorio modder, so I don't know if that's a "good" solution - feel free to do something different and reject this PR.

Additionally, I don't know if you'd have to do something similar in https://github.com/igoticecream/factorio-enemy-alert/blob/9c54455520f1ecb2a4103140a85a37366751f5c0/control.lua#L88 - I don't know if that event could also be fired within compound commands, I never got an issue here with the Enemy Race Manager mod so I didn't touch it. At least, it wouldn't crash, since you guard setting the pin with `defines.command.build_base`, thus compound commands don't reach the code causing the crash in the other case in the first place.